### PR TITLE
feat: Implement JSX support with h() function

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,57 +1,35 @@
+/** @jsx h */
+
 // --- Global reactive signal ---
 const [count, setCount] = signal(0);
 
 // Counter Component
-class Counter extends ReactiveComponent {
-  render() {
-    return `
-      <div class="counter">Count: ${count()}</div>
-      <div class="counterBtnGroup">
-        <button class="increment">+</button>
-        <button class="decrement">-</button>
-      </div>
-    `;
-  }
-
-  afterMount() {
-    this.element
-      .querySelector('.increment')
-      .addEventListener('click', () => setCount(count() + 1));
-
-    this.element
-      .querySelector('.decrement')
-      .addEventListener('click', () => setCount(count() - 1));
-  }
+function Counter() {
+  return (
+    <div class="container">
+      <h1>{count}</h1>
+      <button onClick={() => setCount(count() + 1)}>+</button>
+      <button onClick={() => setCount(count() - 1)}>-</button>
+    </div>
+  );
 }
 
 // Hero Component
-class Hero extends ReactiveComponent {
-  render() {
-    return `
-      <section class="hero">
-        <h2>${this.props.header}</h2>
-        <p>${this.props.description}</p>
-        <div class="counter-mount"></div>
-      </section>
-    `;
-  }
-
-  afterMount() {
-    new Counter().mount('.counter-mount');
-  }
+function Hero(props) {
+  return (
+    <section class="hero">
+      <h2>{props.header}</h2>
+      <p>{props.description}</p>
+      <Counter />
+    </section>
+  );
 }
 
 // --- Setup ---
-document.addEventListener('DOMContentLoaded', () => {
-  const root = document.querySelector('#root');
-  if (!root) {
-    console.error('No #root found');
-    return;
-  }
-
-  new Hero({
-    header: 'MicroView: Build Views With JavaScript',
-    description:
-      'A tiny component and state management framework built entirely with vanilla JavaScript — now reactive with signals.',
-  }).mount('#root');
-});
+mount(
+  '#root',
+  () => <Hero
+    header="MicroView: Build Views With JavaScript"
+    description="A tiny component and state management framework built entirely with vanilla JavaScript — now reactive with signals."
+  />
+);

--- a/index.html
+++ b/index.html
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="styles.css" />
     <title>MicroView.js</title>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
     <script src="./microview.js"></script>
-    <script src="./app.js"></script>
+    <script type="text/babel" src="./app.js"></script>
   </body>
 </html>

--- a/microview.js
+++ b/microview.js
@@ -27,6 +27,46 @@ function effect(fn) {
   wrapped();
 }
 
+function h(tag, props, ...children) {
+  if (typeof tag === 'function') {
+    return tag({ ...(props || {}), children });
+  }
+
+  const el = document.createElement(tag);
+
+  for (const key in props) {
+    if (key.startsWith('on')) {
+      el.addEventListener(key.slice(2).toLowerCase(), props[key]);
+    } else {
+      el.setAttribute(key, props[key]);
+    }
+  }
+
+  children.flat().forEach((child) => {
+    if (child instanceof HTMLElement) {
+      el.appendChild(child);
+    } else if (typeof child === 'function') {
+      const textNode = document.createTextNode('');
+      el.appendChild(textNode);
+      effect(() => {
+        textNode.nodeValue = child();
+      });
+    } else if (child !== null && child !== undefined) {
+      el.appendChild(document.createTextNode(String(child)));
+    }
+  });
+
+  return el;
+}
+
+function mount(selector, component) {
+  const target = document.querySelector(selector);
+  if (!target) {
+    throw new Error(`[mount] No element found for selector: ${selector}`);
+  }
+  target.appendChild(component());
+}
+
 // Base Component Class
 class Component {
   constructor(props = {}) {


### PR DESCRIPTION
This commit introduces a hyperscript-style `h()` function to enable JSX-driven development within the micro-framework. It also includes a `mount` function for rendering components to the DOM.

Key changes:
- Added `h()` function to `microview.js` to create DOM elements from JSX syntax, handling props, event listeners, and children.
- Implemented reactivity within `h()` to automatically update the DOM when signal values change.
- Added a `mount()` function to `microview.js` to append components to a target DOM element.
- Refactored `app.js` to use functional components with JSX syntax, replacing the previous class-based approach.
- Updated `index.html` to use Babel for in-browser JSX transpilation.